### PR TITLE
Openssl version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ test/ldap/openldap-data/run/slapd.*
 test/rails_app/tmp
 pkg/*
 *.gem
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ To start hacking on `devise_ldap_authentication`, clone the github repository, s
     # in a separate console or backgrounded
     ./spec/ldap/run-server
 
-    bundle exec rake db:migrate # first time only
+    bundle exec rake db:migrate
+    RAILS_ENV=test bundle exec rake db:migrate # first time only
     bundle exec rake spec
 
 References

--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -6,32 +6,33 @@ require 'devise_ldap_authenticatable/logger'
 require 'devise_ldap_authenticatable/ldap/adapter'
 require 'devise_ldap_authenticatable/ldap/connection'
 require 'devise_ldap_authenticatable/ldap/wrapper'
+require 'devise_ldap_authenticatable/ssl/ssl_version_setter'
 
 # Get ldap information from config/ldap.yml now
 module Devise
   # Allow logging
   mattr_accessor :ldap_logger
   @@ldap_logger = true
-  
+
   # Add valid users to database
   mattr_accessor :ldap_create_user
   @@ldap_create_user = false
-  
+
   mattr_accessor :ldap_config
   # @@ldap_config = "#{Rails.root}/config/ldap.yml"
-  
+
   mattr_accessor :ldap_update_password
   @@ldap_update_password = true
-  
+
   mattr_accessor :ldap_check_group_membership
   @@ldap_check_group_membership = false
-  
+
   mattr_accessor :ldap_check_attributes
   @@ldap_check_role_attribute = false
-  
+
   mattr_accessor :ldap_use_admin_to_bind
   @@ldap_use_admin_to_bind = false
-  
+
   mattr_accessor :ldap_auth_username_builder
   @@ldap_auth_username_builder = Proc.new() {|attribute, login, ldap| "#{attribute}=#{login},#{ldap.base}" }
 

--- a/lib/devise_ldap_authenticatable/ssl/ssl_version_setter.rb
+++ b/lib/devise_ldap_authenticatable/ssl/ssl_version_setter.rb
@@ -5,8 +5,7 @@ module Devise
     class SSLConnextionFactory
       def self.new_ssl_connection(io)
         raise Net::LDAP::LdapError, "OpenSSL is unavailable" unless Net::LDAP::HasOpenSSL
-        ctx = OpenSSL::SSL::SSLContext.new
-        ctx.ssl_version = :TLSv1
+        ctx = OpenSSL::SSL::SSLContext.new(:TLSv1)
         conn = OpenSSL::SSL::SSLSocket.new(io, ctx)
         conn.connect
         conn.sync_close = true

--- a/lib/devise_ldap_authenticatable/ssl/ssl_version_setter.rb
+++ b/lib/devise_ldap_authenticatable/ssl/ssl_version_setter.rb
@@ -1,0 +1,27 @@
+require 'net-ldap'
+
+module Devise
+  module LDAP
+    class SSLConnextionFactory
+      def self.new_ssl_connection(io)
+        raise Net::LDAP::LdapError, "OpenSSL is unavailable" unless Net::LDAP::HasOpenSSL
+        ctx = OpenSSL::SSL::SSLContext.new
+        ctx.ssl_version = :TLSv1
+        conn = OpenSSL::SSL::SSLSocket.new(io, ctx)
+        conn.connect
+        conn.sync_close = true
+
+        conn.extend(Net::LDAP::Connection::GetbyteForSSLSocket) unless conn.respond_to?(:getbyte)
+
+        conn
+      end
+    end
+  end
+end
+
+
+class Net::LDAP::Connection
+  def self.wrap_with_ssl(io)
+    Devise::LDAP::SSLConnextionFactory.new_ssl_connection(io)
+  end
+end

--- a/spec/rails_app/db/schema.rb
+++ b/spec/rails_app/db/schema.rb
@@ -13,7 +13,7 @@
 
 ActiveRecord::Schema.define(version: 20100708120448) do
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -344,4 +344,28 @@ describe 'Users' do
     end
   end
 
+  describe 'SSL' do
+
+    let(:context){ double }
+    let(:connection) { double.as_null_object }
+    let(:user){ Factory.create(:user) }
+
+    before do
+      allow(ENV).to receive(:[]).with("LDAP_SSL").and_return(true)
+      default_devise_settings!
+      allow_any_instance_of(Devise::LDAP::Wrapper).to receive(:each_server).and_return([])
+    end
+
+    it 'uses the TLS version of SSL' do
+      expect(OpenSSL::SSL::SSLContext).to receive(:new).with(:TLSv1).and_return(context)
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(anything(), context).and_return(connection)
+      expect(connection).to receive(:connect)
+      begin
+        user.valid_ldap_authentication?('x')
+      rescue => _
+        # Connection won't really happen an an exception will
+      end
+    end
+  end
+
 end

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -140,25 +140,25 @@ describe 'Users' do
         should_not_be_validated @user, "secret"
       end
     end
-    
+
     describe "check group membership" do
       before do
         @admin = Factory.create(:admin)
         @user = Factory.create(:user)
       end
-      
+
       it "should return true for admin being in the admins group" do
         assert_equal true, @admin.in_ldap_group?('cn=admins,ou=groups,dc=test,dc=com')
       end
-      
+
       it "should return false for admin being in the admins group using the 'foobar' group attribute" do
         assert_equal false, @admin.in_ldap_group?('cn=admins,ou=groups,dc=test,dc=com', 'foobar')
       end
-      
+
       it "should return true for user being in the users group" do
         assert_equal true, @user.in_ldap_group?('cn=users,ou=groups,dc=test,dc=com')
-      end   
-      
+      end
+
       it "should return false for user being in the admins group" do
         assert_equal false, @user.in_ldap_group?('cn=admins,ou=groups,dc=test,dc=com')
       end
@@ -167,7 +167,7 @@ describe 'Users' do
         assert_equal false, @user.in_ldap_group?('cn=thisgroupdoesnotexist,ou=groups,dc=test,dc=com')
       end
     end
-    
+
 
     describe "use role attribute for authorization" do
       before do
@@ -244,9 +244,7 @@ describe 'Users' do
       end
 
       it "should not call ldap_before_save hook if not defined" do
-        assert_nothing_raised do
           should_be_validated Factory.create(:user, :uid => "example_user"), "secret"
-        end
       end
     end
   end
@@ -272,7 +270,7 @@ describe 'Users' do
       describe "when all servers are down" do
         before :each do
           Net::LDAP.any_instance.stub(:search) do |a|
-            raise Net::LDAP::LdapError.new("No such address or other socket error") 
+            raise Net::LDAP::LdapError.new("No such address or other socket error")
           end
         end
 
@@ -286,7 +284,7 @@ describe 'Users' do
           Net::LDAP.any_instance.stub(:search) do |a|
             unless defined? @first_server
               @first_server = true
-              raise Net::LDAP::LdapError.new("No such address or other socket error") 
+              raise Net::LDAP::LdapError.new("No such address or other socket error")
             end
           end
         end
@@ -327,9 +325,7 @@ describe 'Users' do
     end
 
     it "should not fail if config file has ssl: true" do
-      assert_nothing_raised do
         Devise::LDAP::Connection.new
-      end
     end
   end
 

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -353,7 +353,6 @@ describe 'Users' do
     before do
       allow(ENV).to receive(:[]).with("LDAP_SSL").and_return(true)
       default_devise_settings!
-      allow_any_instance_of(Devise::LDAP::Wrapper).to receive(:each_server).and_return([])
     end
 
     it 'uses the TLS version of SSL' do
@@ -362,8 +361,9 @@ describe 'Users' do
       expect(connection).to receive(:connect)
       begin
         user.valid_ldap_authentication?('x')
-      rescue => _
-        # Connection won't really happen an an exception will
+      rescue => e
+        # We expect this error as SSL is not properly set on the fake server so ignore it
+        raise unless e.message == 'Failover is not configured'
       end
     end
   end


### PR DESCRIPTION
@simplybusiness/developers I added the Monkeypatch for the latest openSSL - Ldap error in this gem.
This basically forces the TLSv1 version of SSL to be used in the LDAP client. This allows the latest openssl to still work with our LDAP. 

It is not beautiful code by any measure, in particular couldn't figure out how to make better testing work for this. so please review.

I will also tell Hazal to kindly test this on integration environment if people is happy to take this monkeypatch forward.