### PR TITLE
Fix OpenSSL::SSL::SSLError: SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A

### DIFF
--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('devise', '>= 3.4.1')
-  s.add_dependency('net-ldap', '>= 0.6.0', '<= 0.11')
+  s.add_dependency('net-ldap', '>= 0.6.0', '<= 0.12.1')
 
   s.add_development_dependency('rake', '>= 0.9')
   s.add_development_dependency('rdoc', '>= 3')

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -13,7 +13,15 @@ module Devise
         end
         ldap_options = params
         ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
-        ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
+        if ldap_config["ssl"]
+          ldap_options[:encryption] = {
+            method: ldap_config["ssl"],
+            tls_options: {
+              ssl_version: :TLSv1,
+              verify_mode: OpenSSL::SSL::VERIFY_NONE
+            }
+          }
+        end
         self.ldap_config = ldap_config
         self.ldap_options = ldap_options
 


### PR DESCRIPTION
### Description

This will take care of the error people are getting on ldap local `OpenSSL::SSL::SSLError: SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A`. Even tho this is ignoring SSL validation it's still a better approach than downgrading openssl.

### Sign-off

@jaynefox @waynemoore @DariuszMusielak please take a look and sign off

### Note

@jaynefox is looking into checking what certificate we're using so that we can get rid of the `verify_mode: OpenSSL::SSL::VERIFY_NONE` option.