### PR TITLE
Force RC4 cipher for our ancient LDAP server

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -12,8 +12,17 @@ module Devise
           ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
         end
         ldap_options = params
-        ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
-        ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
+        if ldap_config['ssl'] === true
+          ldap_options[:encryption] = {
+            method: :simple_tls,
+            tls_options: {
+              ssl_version: 'SSLv23',
+              verify_mode: 1,
+              ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES128-SHA256:DHE-DSS-AES256-SHA256:DHE-DSS-AES128-SHA:DHE-DSS-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:ECDHE-ECDSA-RC4-SHA:ECDHE-RSA-RC4-SHA:RC4-SHA',
+              options: 2097019905
+            }
+          }
+        end
         self.ldap_config = ldap_config
         self.ldap_options = ldap_options
 


### PR DESCRIPTION
Windows 2003's LDAP server only supports RC4 cipher.
Given we only care whether we use SSL or not, when SSL is enabled, encryption is set to simple_tls and the supported ciphers are set.

Recently, Ruby's 2.4 openssl gem has removed RC4 from its default params, however doesn't disallow its usage. See: https://github.com/ruby/openssl/pull/50
By letting our LDAP server we want to use RC4, we are able to communicate with it.

**BONUS:** By merging this PR means we can remove the LDAP monkey patch from our apps!

Tested by @sivalpatel and @ed-woodfall locally
