### PR TITLE
Revert previous cipher change

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -12,17 +12,8 @@ module Devise
           ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
         end
         ldap_options = params
-        if ldap_config['ssl'] === true
-          ldap_options[:encryption] = {
-            method: :simple_tls,
-            tls_options: {
-              ssl_version: 'SSLv23',
-              verify_mode: 1,
-              ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES128-SHA256:DHE-DSS-AES256-SHA256:DHE-DSS-AES128-SHA:DHE-DSS-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:ECDHE-ECDSA-RC4-SHA:ECDHE-RSA-RC4-SHA:RC4-SHA',
-              options: 2097019905
-            }
-          }
-        end
+        ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
+        ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
         self.ldap_config = ldap_config
         self.ldap_options = ldap_options
 


### PR DESCRIPTION
@dragosmiron @mineshdattani @andrewgristwood @pvdb 

Reverting previous PR which added ciphers in.

This has been tested in Cocoa (by @srp2930 I believe) and in Chopin by me, it works with ruby 229 (what we are currently on) and ruby 243 (what we aim to be on), I will reintroduce th ldap file back into the .gitignore for chopin too